### PR TITLE
Build only specific Function using --env.{FunctionName} option 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,4 +171,4 @@ class AwsSamPlugin {
   }
 }
 
-module.exports = AwsSamPlugin;
+export = AwsSamPlugin


### PR DESCRIPTION
Now build command builds all Functions Even When I want to test a single Function.

How to use

1. constructor
    const awsSamPlugin = new AwsSamPlugin({options: null,  env});
2. command
    yarn run build --env.func={FunctionName in template.yaml}