### PR TITLE
fix: typescript definitions are empty (#28)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+char_set = utf-8
+insert_final_newline = true
+
+[*.{ts,js,json}]
+indent_size = 2

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ class AwsSamPlugin {
   }
 
   public apply(compiler: any) {
-    compiler.hooks.afterEmit.tap("SamPlugin", (compilation: any) => {
+    compiler.hooks.afterEmit.tap("SamPlugin", (_compilation: any) => {
       if (this.samConfigs && this.launchConfig) {
         for (const samConfig of this.samConfigs) {
           fs.writeFileSync(`${samConfig.buildRoot}/template.yaml`, yamlDump(samConfig.samConfig));
@@ -172,3 +172,4 @@ class AwsSamPlugin {
 }
 
 module.exports = AwsSamPlugin;
+export default AwsSamPlugin;


### PR DESCRIPTION
* replace module.exports with a default export to enable typescript definitions to be generated
* add an _ to the unused `compilation` argument in the sam plugin
* add an .editorconfig to match existing styles so editors don't modify whitespace

Closes: #28 