### PR TITLE
Add support for nodejs22.x runtime

### DIFF
--- a/src/__tests__/__snapshots__/entryFor.test.ts.snap
+++ b/src/__tests__/__snapshots__/entryFor.test.ts.snap
@@ -39,7 +39,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -96,7 +96,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -153,7 +153,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -205,7 +205,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -262,7 +262,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -319,163 +319,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
-            },
-            "Type": "AWS::Serverless::Function",
-          },
-        },
-        "Transform": "AWS::Serverless-2016-10-31",
-      },
-      "templateName": "template.yaml",
-    },
-  ],
-}
-`;
-
-exports[`Function Runtime can be set at the function to nodejs14.x 1`] = `
-Object {
-  "entryPoints": Object {
-    "MyLambda": "./src/my-lambda/app",
-  },
-  "launchConfigs": Array [
-    Object {
-      "address": "localhost",
-      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
-      "name": "MyLambda",
-      "outFiles": Array [
-        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
-      ],
-      "port": 5858,
-      "protocol": "inspector",
-      "remoteRoot": "/var/task",
-      "request": "attach",
-      "skipFiles": Array [
-        "/var/runtime/**/*.js",
-        "<node_internals>/**/*.js",
-      ],
-      "sourceMaps": true,
-      "stopOnEntry": false,
-      "type": "node",
-    },
-  ],
-  "samConfigs": Array [
-    Object {
-      "buildRoot": ".aws-sam/build",
-      "entryPointName": "MyLambda",
-      "outFile": "./.aws-sam/build/MyLambda/app.js",
-      "projectKey": "default",
-      "samConfig": Object {
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Resources": Object {
-          "MyLambda": Object {
-            "Properties": Object {
-              "CodeUri": "MyLambda",
-              "Handler": "app.handler",
-              "Runtime": "nodejs14.x",
-            },
-            "Type": "AWS::Serverless::Function",
-          },
-        },
-        "Transform": "AWS::Serverless-2016-10-31",
-      },
-      "templateName": "template.yaml",
-    },
-  ],
-}
-`;
-
-exports[`Function Runtime can be set at the function to nodejs14.x 1`] = `
-Object {
-  "entryPoints": Object {
-    "MyLambda": "./src/my-lambda/app",
-  },
-  "launchConfigs": Array [
-    Object {
-      "address": "localhost",
-      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
-      "name": "MyLambda",
-      "outFiles": Array [
-        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
-      ],
-      "port": 5858,
-      "protocol": "inspector",
-      "remoteRoot": "/var/task",
-      "request": "attach",
-      "skipFiles": Array [
-        "/var/runtime/**/*.js",
-        "<node_internals>/**/*.js",
-      ],
-      "sourceMaps": true,
-      "stopOnEntry": false,
-      "type": "node",
-    },
-  ],
-  "samConfigs": Array [
-    Object {
-      "buildRoot": ".aws-sam/build",
-      "entryPointName": "MyLambda",
-      "outFile": "./.aws-sam/build/MyLambda/app.js",
-      "projectKey": "default",
-      "samConfig": Object {
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Resources": Object {
-          "MyLambda": Object {
-            "Properties": Object {
-              "CodeUri": "MyLambda",
-              "Handler": "app.handler",
-              "Runtime": "nodejs14.x",
-            },
-            "Type": "AWS::Serverless::Function",
-          },
-        },
-        "Transform": "AWS::Serverless-2016-10-31",
-      },
-      "templateName": "template.yaml",
-    },
-  ],
-}
-`;
-
-exports[`Function Runtime can be set at the function to nodejs16.x 1`] = `
-Object {
-  "entryPoints": Object {
-    "MyLambda": "./src/my-lambda/app",
-  },
-  "launchConfigs": Array [
-    Object {
-      "address": "localhost",
-      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
-      "name": "MyLambda",
-      "outFiles": Array [
-        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
-      ],
-      "port": 5858,
-      "protocol": "inspector",
-      "remoteRoot": "/var/task",
-      "request": "attach",
-      "skipFiles": Array [
-        "/var/runtime/**/*.js",
-        "<node_internals>/**/*.js",
-      ],
-      "sourceMaps": true,
-      "stopOnEntry": false,
-      "type": "node",
-    },
-  ],
-  "samConfigs": Array [
-    Object {
-      "buildRoot": ".aws-sam/build",
-      "entryPointName": "MyLambda",
-      "outFile": "./.aws-sam/build/MyLambda/app.js",
-      "projectKey": "default",
-      "samConfig": Object {
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Resources": Object {
-          "MyLambda": Object {
-            "Properties": Object {
-              "CodeUri": "MyLambda",
-              "Handler": "app.handler",
-              "Runtime": "nodejs16.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -592,6 +436,58 @@ Object {
 }
 `;
 
+exports[`Function Runtime can be set at the function to nodejs22.x 1`] = `
+Object {
+  "entryPoints": Object {
+    "MyLambda": "./src/my-lambda/app",
+  },
+  "launchConfigs": Array [
+    Object {
+      "address": "localhost",
+      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
+      "name": "MyLambda",
+      "outFiles": Array [
+        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
+      ],
+      "port": 5858,
+      "protocol": "inspector",
+      "remoteRoot": "/var/task",
+      "request": "attach",
+      "skipFiles": Array [
+        "/var/runtime/**/*.js",
+        "<node_internals>/**/*.js",
+      ],
+      "sourceMaps": true,
+      "stopOnEntry": false,
+      "type": "node",
+    },
+  ],
+  "samConfigs": Array [
+    Object {
+      "buildRoot": ".aws-sam/build",
+      "entryPointName": "MyLambda",
+      "outFile": "./.aws-sam/build/MyLambda/app.js",
+      "projectKey": "default",
+      "samConfig": Object {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": Object {
+          "MyLambda": Object {
+            "Properties": Object {
+              "CodeUri": "MyLambda",
+              "Handler": "app.handler",
+              "Runtime": "nodejs22.x",
+            },
+            "Type": "AWS::Serverless::Function",
+          },
+        },
+        "Transform": "AWS::Serverless-2016-10-31",
+      },
+      "templateName": "template.yaml",
+    },
+  ],
+}
+`;
+
 exports[`Function Runtime can be set global and at function 1`] = `
 Object {
   "entryPoints": Object {
@@ -628,7 +524,7 @@ Object {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Globals": Object {
           "Function": Object {
-            "Runtime": "nodejs18.x",
+            "Runtime": "nodejs20.x",
           },
         },
         "Resources": Object {
@@ -636,175 +532,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
-            },
-            "Type": "AWS::Serverless::Function",
-          },
-        },
-        "Transform": "AWS::Serverless-2016-10-31",
-      },
-      "templateName": "template.yaml",
-    },
-  ],
-}
-`;
-
-exports[`Function Runtime can be set globally to nodejs14.x 1`] = `
-Object {
-  "entryPoints": Object {
-    "MyLambda": "./src/my-lambda/app",
-  },
-  "launchConfigs": Array [
-    Object {
-      "address": "localhost",
-      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
-      "name": "MyLambda",
-      "outFiles": Array [
-        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
-      ],
-      "port": 5858,
-      "protocol": "inspector",
-      "remoteRoot": "/var/task",
-      "request": "attach",
-      "skipFiles": Array [
-        "/var/runtime/**/*.js",
-        "<node_internals>/**/*.js",
-      ],
-      "sourceMaps": true,
-      "stopOnEntry": false,
-      "type": "node",
-    },
-  ],
-  "samConfigs": Array [
-    Object {
-      "buildRoot": ".aws-sam/build",
-      "entryPointName": "MyLambda",
-      "outFile": "./.aws-sam/build/MyLambda/app.js",
-      "projectKey": "default",
-      "samConfig": Object {
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Globals": Object {
-          "Function": Object {
-            "Runtime": "nodejs14.x",
-          },
-        },
-        "Resources": Object {
-          "MyLambda": Object {
-            "Properties": Object {
-              "CodeUri": "MyLambda",
-              "Handler": "app.handler",
-            },
-            "Type": "AWS::Serverless::Function",
-          },
-        },
-        "Transform": "AWS::Serverless-2016-10-31",
-      },
-      "templateName": "template.yaml",
-    },
-  ],
-}
-`;
-
-exports[`Function Runtime can be set globally to nodejs14.x 1`] = `
-Object {
-  "entryPoints": Object {
-    "MyLambda": "./src/my-lambda/app",
-  },
-  "launchConfigs": Array [
-    Object {
-      "address": "localhost",
-      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
-      "name": "MyLambda",
-      "outFiles": Array [
-        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
-      ],
-      "port": 5858,
-      "protocol": "inspector",
-      "remoteRoot": "/var/task",
-      "request": "attach",
-      "skipFiles": Array [
-        "/var/runtime/**/*.js",
-        "<node_internals>/**/*.js",
-      ],
-      "sourceMaps": true,
-      "stopOnEntry": false,
-      "type": "node",
-    },
-  ],
-  "samConfigs": Array [
-    Object {
-      "buildRoot": ".aws-sam/build",
-      "entryPointName": "MyLambda",
-      "outFile": "./.aws-sam/build/MyLambda/app.js",
-      "projectKey": "default",
-      "samConfig": Object {
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Globals": Object {
-          "Function": Object {
-            "Runtime": "nodejs14.x",
-          },
-        },
-        "Resources": Object {
-          "MyLambda": Object {
-            "Properties": Object {
-              "CodeUri": "MyLambda",
-              "Handler": "app.handler",
-            },
-            "Type": "AWS::Serverless::Function",
-          },
-        },
-        "Transform": "AWS::Serverless-2016-10-31",
-      },
-      "templateName": "template.yaml",
-    },
-  ],
-}
-`;
-
-exports[`Function Runtime can be set globally to nodejs16.x 1`] = `
-Object {
-  "entryPoints": Object {
-    "MyLambda": "./src/my-lambda/app",
-  },
-  "launchConfigs": Array [
-    Object {
-      "address": "localhost",
-      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
-      "name": "MyLambda",
-      "outFiles": Array [
-        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
-      ],
-      "port": 5858,
-      "protocol": "inspector",
-      "remoteRoot": "/var/task",
-      "request": "attach",
-      "skipFiles": Array [
-        "/var/runtime/**/*.js",
-        "<node_internals>/**/*.js",
-      ],
-      "sourceMaps": true,
-      "stopOnEntry": false,
-      "type": "node",
-    },
-  ],
-  "samConfigs": Array [
-    Object {
-      "buildRoot": ".aws-sam/build",
-      "entryPointName": "MyLambda",
-      "outFile": "./.aws-sam/build/MyLambda/app.js",
-      "projectKey": "default",
-      "samConfig": Object {
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Globals": Object {
-          "Function": Object {
-            "Runtime": "nodejs16.x",
-          },
-        },
-        "Resources": Object {
-          "MyLambda": Object {
-            "Properties": Object {
-              "CodeUri": "MyLambda",
-              "Handler": "app.handler",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -929,6 +657,62 @@ Object {
 }
 `;
 
+exports[`Function Runtime can be set globally to nodejs22.x 1`] = `
+Object {
+  "entryPoints": Object {
+    "MyLambda": "./src/my-lambda/app",
+  },
+  "launchConfigs": Array [
+    Object {
+      "address": "localhost",
+      "localRoot": "\${workspaceFolder}/.aws-sam/build/MyLambda",
+      "name": "MyLambda",
+      "outFiles": Array [
+        "\${workspaceFolder}/.aws-sam/build/MyLambda/**/*.js",
+      ],
+      "port": 5858,
+      "protocol": "inspector",
+      "remoteRoot": "/var/task",
+      "request": "attach",
+      "skipFiles": Array [
+        "/var/runtime/**/*.js",
+        "<node_internals>/**/*.js",
+      ],
+      "sourceMaps": true,
+      "stopOnEntry": false,
+      "type": "node",
+    },
+  ],
+  "samConfigs": Array [
+    Object {
+      "buildRoot": ".aws-sam/build",
+      "entryPointName": "MyLambda",
+      "outFile": "./.aws-sam/build/MyLambda/app.js",
+      "projectKey": "default",
+      "samConfig": Object {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Globals": Object {
+          "Function": Object {
+            "Runtime": "nodejs22.x",
+          },
+        },
+        "Resources": Object {
+          "MyLambda": Object {
+            "Properties": Object {
+              "CodeUri": "MyLambda",
+              "Handler": "app.handler",
+            },
+            "Type": "AWS::Serverless::Function",
+          },
+        },
+        "Transform": "AWS::Serverless-2016-10-31",
+      },
+      "templateName": "template.yaml",
+    },
+  ],
+}
+`;
+
 exports[`It ignores non AWS::Serverless::Function resosurces 1`] = `
 Object {
   "entryPoints": Object {
@@ -971,7 +755,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },
@@ -1020,7 +804,7 @@ Object {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Globals": Object {
           "Function": Object {
-            "Runtime": "nodejs20.x",
+            "Runtime": "nodejs22.x",
           },
         },
         "Resources": Object {
@@ -1076,7 +860,7 @@ Object {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Globals": Object {
           "Function": Object {
-            "Runtime": "nodejs20.x",
+            "Runtime": "nodejs22.x",
           },
         },
         "Resources": Object {
@@ -1132,7 +916,7 @@ Object {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Globals": Object {
           "Function": Object {
-            "Runtime": "nodejs18.x",
+            "Runtime": "nodejs20.x",
           },
         },
         "Resources": Object {
@@ -1140,7 +924,7 @@ Object {
             "Properties": Object {
               "CodeUri": "MyLambda",
               "Handler": "app.handler",
-              "Runtime": "nodejs20.x",
+              "Runtime": "nodejs22.x",
             },
             "Type": "AWS::Serverless::Function",
           },

--- a/src/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/__tests__/__snapshots__/integration.test.ts.snap
@@ -10,7 +10,7 @@ Object {
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -32,7 +32,7 @@ Object {
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -78,7 +78,7 @@ Object {
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -124,7 +124,7 @@ Object {
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -170,7 +170,7 @@ Object {
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -260,7 +260,7 @@ Object {
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -272,7 +272,7 @@ Resources:
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -338,7 +338,7 @@ Object {
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function
@@ -350,7 +350,7 @@ Resources:
 Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 Resources:
   MyLambda:
     Type: AWS::Serverless::Function

--- a/src/__tests__/entryFor.test.ts
+++ b/src/__tests__/entryFor.test.ts
@@ -1,48 +1,6 @@
 import SamPlugin from "../index";
 
 describe("Function Runtime", () => {
-  test("can be set globally to nodejs14.x", () => {
-    const plugin = new SamPlugin();
-    const template = `
-AWSTemplateFormatVersion: "2010-09-09"
-Transform: AWS::Serverless-2016-10-31
-
-Globals:
-  Function:
-    Runtime: nodejs14.x
-
-Resources:
-  MyLambda:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: src/my-lambda
-      Handler: app.handler
-`;
-    const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
-    expect(entries).toMatchSnapshot();
-  });
-
-  test("can be set globally to nodejs16.x", () => {
-    const plugin = new SamPlugin();
-    const template = `
-AWSTemplateFormatVersion: "2010-09-09"
-Transform: AWS::Serverless-2016-10-31
-
-Globals:
-  Function:
-    Runtime: nodejs16.x
-
-Resources:
-  MyLambda:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: src/my-lambda
-      Handler: app.handler
-`;
-    const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
-    expect(entries).toMatchSnapshot();
-  });
-
   test("can be set globally to nodejs18.x", () => {
     const plugin = new SamPlugin();
     const template = `
@@ -85,11 +43,15 @@ Resources:
     expect(entries).toMatchSnapshot();
   });
 
-  test("can be set at the function to nodejs14.x", () => {
+  test("can be set globally to nodejs22.x", () => {
     const plugin = new SamPlugin();
     const template = `
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Runtime: nodejs22.x
 
 Resources:
   MyLambda:
@@ -97,25 +59,6 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs14.x
-`;
-    const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
-    expect(entries).toMatchSnapshot();
-  });
-
-  test("can be set at the function to nodejs16.x", () => {
-    const plugin = new SamPlugin();
-    const template = `
-AWSTemplateFormatVersion: "2010-09-09"
-Transform: AWS::Serverless-2016-10-31
-
-Resources:
-  MyLambda:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: src/my-lambda
-      Handler: app.handler
-      Runtime: nodejs16.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -157,6 +100,24 @@ Resources:
     expect(entries).toMatchSnapshot();
   });
 
+  test("can be set at the function to nodejs22.x", () => {
+    const plugin = new SamPlugin();
+    const template = `
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  MyLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/my-lambda
+      Handler: app.handler
+      Runtime: nodejs22.x
+`;
+    const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
+    expect(entries).toMatchSnapshot();
+  });
+
   test("must be set globally or at the function", () => {
     const plugin = new SamPlugin();
     const template = `
@@ -171,7 +132,7 @@ Resources:
       Handler: app.handler
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
-      "MyLambda has an unsupport Runtime. Must be nodejs14.x, nodejs16.x, nodejs18.x or nodejs20.x"
+      "MyLambda has an unsupport Runtime. Must be nodejs18.x, nodejs20.x or nodejs22.x"
     );
   });
 
@@ -183,7 +144,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 Resources:
   MyLambda:
@@ -193,7 +154,7 @@ Resources:
       Handler: app.handler
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
-      "MyLambda has an unsupport Runtime. Must be nodejs14.x, nodejs16.x, nodejs18.x or nodejs20.x"
+      "MyLambda has an unsupport Runtime. Must be nodejs18.x, nodejs20.x or nodejs22.x"
     );
   });
 
@@ -209,10 +170,10 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
-      "MyLambda has an unsupport Runtime. Must be nodejs14.x, nodejs16.x, nodejs18.x or nodejs20.x"
+      "MyLambda has an unsupport Runtime. Must be nodejs18.x, nodejs20.x or nodejs22.x"
     );
   });
 
@@ -224,7 +185,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs18.x
+    Runtime: nodejs20.x
 
 Resources:
   MyLambda:
@@ -232,7 +193,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -247,7 +208,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs18.x
+    Runtime: nodejs20.x
 
 Resources:
   MyLambda:
@@ -255,7 +216,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
   const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
   expect(entries).toMatchSnapshot();
@@ -277,7 +238,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/my-lambda
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -295,7 +256,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -317,7 +278,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -334,7 +295,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/my-lambda
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
       "MyLambda is missing a Handler"
@@ -358,7 +319,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -376,7 +337,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -398,7 +359,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
     expect(entries).toMatchSnapshot();
@@ -415,7 +376,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
     expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
       "MyLambda is missing a CodeUri"
@@ -449,7 +410,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: apphandler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
   expect(() => plugin.entryFor("default", "", "template.yaml", template, "app")).toThrowError(
     'MyLambda Handler must contain exactly one "."'
@@ -468,7 +429,7 @@ Resources:
     Properties:
       InlineCode: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
   const originalLog = console.log;
   console.log = jest.fn();
@@ -489,7 +450,7 @@ describe("Launch config name", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -511,7 +472,7 @@ describe("Launch config name", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -535,7 +496,7 @@ describe("SAM config entryPointName:", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -557,7 +518,7 @@ describe("SAM config entryPointName:", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -581,7 +542,7 @@ describe("When the template is in a subfolder", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -603,7 +564,7 @@ describe("When the template is in a subfolder", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -624,7 +585,7 @@ describe("When the template is in a subfolder", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -645,7 +606,7 @@ describe("When the template is in a subfolder", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -666,7 +627,7 @@ describe("When the template is in a subfolder", () => {
   
   Globals:
     Function:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   Resources:
     MyLambda:
@@ -692,7 +653,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   FakeResource:
     Type: AWS::FakeResource::NahNah
@@ -709,7 +670,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 Resources:
   MyLambda:
@@ -735,7 +696,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::ApiGateway::RestApi
@@ -760,7 +721,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Lambda::Function
@@ -783,7 +744,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::AppSync::GraphQLSchema
@@ -808,7 +769,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::AppSync::Resolver
@@ -833,7 +794,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::AppSync::Resolver
@@ -858,7 +819,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Serverless::Api
@@ -883,7 +844,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Include
@@ -906,7 +867,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::ElasticBeanstalk::ApplicationVersion
@@ -931,7 +892,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::CloudFormation::Stack
@@ -956,7 +917,7 @@ describe("Property paths are rewritten correctly", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Glue::Job
@@ -982,7 +943,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   MyResource:
     Type: AWS::StepFunctions::StateMachine
@@ -1009,7 +970,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::ApiGateway::RestApi
@@ -1035,7 +996,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Lambda::Function
@@ -1061,7 +1022,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::AppSync::GraphQLSchema
@@ -1086,7 +1047,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::AppSync::Resolver
@@ -1111,7 +1072,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::AppSync::Resolver
@@ -1137,7 +1098,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Serverless::Api
@@ -1162,7 +1123,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Include
@@ -1185,7 +1146,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::ElasticBeanstalk::ApplicationVersion
@@ -1211,7 +1172,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::CloudFormation::Stack
@@ -1236,7 +1197,7 @@ describe("Property paths are not re-written when they are objects", () => {
       Properties:
         CodeUri: src/my-lambda
         Handler: app.handler
-        Runtime: nodejs20.x
+        Runtime: nodejs22.x
 
     MyResource:
       Type: AWS::Glue::Job
@@ -1262,7 +1223,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   MyResource:
     Type: AWS::StepFunctions::StateMachine
@@ -1289,7 +1250,7 @@ Resources:
     Properties:
       CodeUri: src/my-lambda
       Handler: app.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 `;
   const entries = plugin.entryFor("default", "", "template.yaml", template, "app");
 });

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -11,7 +11,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 Resources:
   MyLambda:

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,9 +190,9 @@ class AwsSamPlugin {
         }
 
         // Check the runtime is supported
-        if (!["nodejs14.x", "nodejs16.x", "nodejs18.x", "nodejs20.x"].includes(properties.Runtime ?? defaultRuntime)) {
+        if (!["nodejs18.x", "nodejs20.x", "nodejs22.x"].includes(properties.Runtime ?? defaultRuntime)) {
           throw new Error(
-            `${resourceKey} has an unsupport Runtime. Must be nodejs14.x, nodejs16.x, nodejs18.x or nodejs20.x`
+            `${resourceKey} has an unsupport Runtime. Must be nodejs18.x, nodejs20.x or nodejs22.x`
           );
         }
 


### PR DESCRIPTION
Adding support for the nodejs22.x runtime. Also removed nodejs14 & nodejs16 as a valid options since they are no longer listed as [supported runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).

I've copied similar changes to [this PR](https://github.com/StackToolbox/aws-sam-webpack-plugin/pull/89). 